### PR TITLE
Set position when resizing to ensure correct position when reload

### DIFF
--- a/src/components/picture-in-picture.tsx
+++ b/src/components/picture-in-picture.tsx
@@ -65,6 +65,7 @@ export const PictureInPicture: React.FC<Props> = ({
             width: pipState.size.width + delta.width,
             height: pipState.size.height + delta.height,
           },
+          position: { x: _position.x, y: _position.y },
         });
       }}
       className={`rounded-lg overflow-hidden border border-border shadow-lg bg-black ${className}`}


### PR DESCRIPTION
The Picture-In-Picture (PIP) elements had an issue not keeping their position when reloading after resizing.

If they were resized from the left or the top, after reloading the page the PIP component did not keep its state given that its position was not updated when resizing. This PR fixes this issue.

Behavior previous to this PR:
![2025-04-15 17-09-33](https://github.com/user-attachments/assets/f65df9ad-22db-4cef-88cd-3c035ac547d2)

Behavior with this PR:
![2025-04-15 17-09-07](https://github.com/user-attachments/assets/a50fd46c-da88-42a3-8951-65ce7de69a0e)
